### PR TITLE
Remove unnecessary css browser hacks for the paypal button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.2] 2019-10-16
+
+### Meta
+
+- branch: unsafari-hack
+- description: Undo the css browser hacks in TheHoneymoonFundDonateBtn.vue now that the `input[type="image"]` has a valid `src` attribute.
+
+### Updated
+
+- TheHoneymoonFundDonateBtn.vue: Delete the browser style that were explicitly set as Safari and Edge hacks for rendering `input[type="image"]` correctly. While the hacks worked, Chrome rendered a broken image UI. The answer for the chrome fix turned out to fix the need for the safari and edge hacks as well.
+
 ## 1.1. [v1.2.1] 2019-10-16
 
 ### 1.1.1. Meta
@@ -736,6 +747,9 @@ FIXED by simply adding some bottom margin to the `<header>`!
 <!-- TOC -->
 
 - [Changelog](#changelog)
+  - [[v1.2.2] 2019-10-16](#v122-2019-10-16)
+    - [Meta](#meta)
+    - [Updated](#updated)
   - [[v1.2.1] 2019-10-16](#v121-2019-10-16)
     - [Meta](#meta)
     - [Updated](#updated)

--- a/components/TheHoneymoonFundDonateBtn.vue
+++ b/components/TheHoneymoonFundDonateBtn.vue
@@ -93,16 +93,5 @@ export default {
   top: 0;
   bottom: 0;
   left: 0;
-  width: 100%; /* Safari hack to hide input border on hover*/
-  height: 45px; /* Safari hack to hide input border on hover*/
-  min-height: 30px; /* Safari hack to hide input border on hover*/
-  max-height: 55px; /* Safari hack to hide input border on hover*/
-  color: #ffc439; /* Edge hack to hide "transparent" alt text on hover */
-  z-index: -1; /* Edge hack to hide "transparent" alt text */
-}
-@media screen and (min-width: 480px) {
-  .paypal-input {
-    max-width: 300px; /* Safari hack to hide input border on hover*/
-  }
 }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mattanderin.us",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattanderin.us",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Website for Erin and Matt's wedding 🎉",
   "main": "src/index.html",
   "scripts": {


### PR DESCRIPTION
This PR removes unnecessary css browser hacks for hovering over the paypal button. Now that the `input[type="image"]` has a valid `src` attribute, the style hacks are no longer needed.